### PR TITLE
Adds JS helper functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: echartsUtils
 Title: Tools for working with echarts
-Version: 0.5.1
+Version: 0.6.0
 Authors@R: 
     person("Stephen", "Holsenbeck", , "sholsen@alumni.emory.edu", role = c("aut", "cre"))
 Description: Utility functions for working with echarts objects created by echarts4r & echarty

--- a/R/e_opts_axes.R
+++ b/R/e_opts_axes.R
@@ -424,6 +424,7 @@ e_x_axis_formatting = function(e,
 }
 
 
+
 #' e_y_axis_year_formatting
 #' @description generates a list that configures the correct y axis formatting for echarts figs
 #' @family options
@@ -436,6 +437,7 @@ e_x_axis_formatting = function(e,
 #' @param nameTextStyle \code{list} With named parameters. See \href{https://echarts.apache.org/en/option.html#yAxis.nameTextStyle}{Echarts yAxis.nameTextStyle}
 #' @param nameGap \code{num/chr} **Default: 'auto'** uses custom heuristics to determine a best guess. See \link{axis_width}. Otherwise a numeric pixel value
 #' @param mo \code{int} of the magnitude of the units. 9 = Billions, 6 = Millions etc
+#' @param axisPointer Configuration for axisPointer. See `e_opts_axisPointer` for more info.
 #' @return A list of parameters for appropriate y-axis formatting for years on echarts figures
 #' @export
 
@@ -449,7 +451,7 @@ e_y_axis_formatting <- function(e,
                                 nameTextStyle = list(padding = c(0,0,0,0)),
                                 nameGap = 'auto',
                                 mo = NULL,
-                                axisPointer = e_opts_axisPointer(),
+                                axisPointer = NULL,
                                 ...) {
 
 

--- a/inst/srcjs/helpers.js
+++ b/inst/srcjs/helpers.js
@@ -8,4 +8,12 @@ function is_null (x) {
   return x === null | x === undefined;
 }
 
-
+/** Adds a purrr::keep style function to Object
+/* @param obj {Object} object to be filtered
+/* @param predicate {Function} Function to be applied to each sub-object to determine if it should be kept
+/* @return {Object} with only the sub-objects matching the predicate function remaining
+**/
+Object.keep = (obj, predicate) =>
+    Object.keys(obj)
+          .filter( key => predicate(obj[key]) )
+          .reduce( (res, key) => (res[key] = obj[key], res), {} );

--- a/inst/srcjs/helpers.js
+++ b/inst/srcjs/helpers.js
@@ -18,4 +18,50 @@ Object.keep = (obj, predicate) =>
     Object.keys(obj)
           .filter( key => predicate(obj[key]) )
           .reduce( (res, key) => (res[key] = obj[key], res), {} );
-        
+
+
+/**
+ * Generate a sequence of numbers
+ * @param {Number} start
+ * @param {Number} end
+ * @returns {Array} with sequence from start to end
+ */
+function seq(start, end) {
+  return Array(end - start + 1).fill().map((_, idx) => start + idx)
+}
+
+/**
+ * @param  {String} selector
+ * @returns  {Logical}
+ */
+function isVisible(selector) {
+  return $(selector).is(":visible");
+}
+
+/**
+ * @param selector {String} selector
+ * @usage waitForEl('.some-class').then((elm) => {
+    console.log('Element is ready');
+    console.log(elm.textContent);
+});
+* @credit https://stackoverflow.com/a/61511955
+ */
+function waitForEl(selector) {
+    return new Promise(resolve => {
+        if (document.querySelector(selector)) {
+            return resolve(document.querySelector(selector));
+        }
+
+        const observer = new MutationObserver(mutations => {
+            if (document.querySelector(selector)) {
+                resolve(document.querySelector(selector));
+                observer.disconnect();
+            }
+        });
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+    });
+}

--- a/inst/srcjs/helpers.js
+++ b/inst/srcjs/helpers.js
@@ -8,12 +8,14 @@ function is_null (x) {
   return x === null | x === undefined;
 }
 
-/** Adds a purrr::keep style function to Object
-/* @param obj {Object} object to be filtered
-/* @param predicate {Function} Function to be applied to each sub-object to determine if it should be kept
+
+/** Adds a purrr::keep style function to Object. Useful for filtering `params` objects in tooltip callbacks
+/* @param {Object} obj  object to be filtered
+/* @param {Function} predicate  Function to be applied to each sub-object to determine if it should be kept
 /* @return {Object} with only the sub-objects matching the predicate function remaining
 **/
 Object.keep = (obj, predicate) =>
     Object.keys(obj)
           .filter( key => predicate(obj[key]) )
           .reduce( (res, key) => (res[key] = obj[key], res), {} );
+        

--- a/inst/srcjs/helpers.js
+++ b/inst/srcjs/helpers.js
@@ -65,3 +65,16 @@ function waitForEl(selector) {
         });
     });
 }
+
+/**
+ * Returns unique values in an array
+ * @param {Array} array
+ * @returns {Array} of unique values
+ */
+function unique(array) {
+  function onlyUnique(value, index, array) {
+    return array.indexOf(value) === index;
+  }
+  var out = array.filter(onlyUnique);
+  return out;
+}


### PR DESCRIPTION
This adds:
 - In the style of `purrr::keep`, a method of `Object.keep` that allows for filtering and keeping only sub-objects matching a predicate function `true` result within an object.
 - `seq`: a JS equivalent to R's `seq`
 - `isVisible`: checks if an element is visible on the page
 - `waitForEl`: waits for an element to become visible, then returns `true`, see usage.
 
 Bill [here](https://virgalabs.atlassian.net/browse/DMDU-82?atlOrigin=eyJpIjoiYWRjMDQ0ZTg2NWE0NDI0NGJhYTljZWEzNmExZjMzOWUiLCJwIjoiaiJ9)